### PR TITLE
Support other asset type prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ params = {
 }
 v1client = VersiononeSdk::Client.new params
 
+# Different asset types can be defined and passed in during instantiation
+params = {
+  ...
+  type_prefixes: { 'R' => 'Request', 'D' => 'Defect', 'B' => 'Story', 'E' => 'Epic' }
+}
+v1client = VersiononeSdk::Client.new params
+
 # Retrieve an array of VersiononeSdk::Asset objects
 assets   = v1client.getAssets('Scope')
 

--- a/lib/versionone_sdk/client.rb
+++ b/lib/versionone_sdk/client.rb
@@ -10,6 +10,7 @@ module VersiononeSdk
 
     attr_accessor :oFaraday
     attr_accessor :sInstance
+    attr_accessor :dTypePrefix
 
     def initialize(opts = {})
       @sProtocol   = opts[:protocol] || DEFAULT_PROTOCOL
@@ -21,7 +22,7 @@ module VersiononeSdk
       # VersionOne provides a mechanism for generating an access token
       sAccessToken = opts[:access_token] || ''
       @sInstance   = opts[:instance] || ''
-      @dTypePrefix = {'B' => 'Story', 'E' => 'Epic'}
+      @dTypePrefix = opts[:type_prefixes] || {'B' => 'Story', 'E' => 'Epic', 'D' => 'Defect'}
       @sUrl        = buildUrl(@sProtocol, @sHostname, @iPort)
       @oFaraday    = Faraday::Connection.new url: @sUrl
       @oFaraday.ssl.verify = opts[:ssl_verify].to_s.match(/false/i) \

--- a/lib/versionone_sdk/parser_xml_assets.rb
+++ b/lib/versionone_sdk/parser_xml_assets.rb
@@ -62,10 +62,9 @@ module VersiononeSdk
             xxPropVal = getAssetNodeChildPropVal( oNodeChild )
             oAsset.setProp(yPropKey,xxPropVal)
           end
+        elsif oNodeChild.name == 'Message' && oNodeChild.text == 'Not Found'
+          raise RuntimeError, "E_ASSET_NOT_FOUND #{oNodeAsset.attribute('href').value}"
         else
-          if oNodeChild.name == 'Message' && oNodeChild.text == 'Not Found'
-            raise RuntimeError, "E_ASSET_NOT_FOUND #{oNodeAsset.attribute('href').value}"
-          end
           raise RuntimeError, "E_UNKNOWN_ASSET_NODE_NAME #{oNodeChild.name}"
         end
       end

--- a/test/test_setup.rb
+++ b/test/test_setup.rb
@@ -39,5 +39,11 @@ class VersiononeSdkTest < Test::Unit::TestCase
     oClient = VersiononeSdk::Client.new(protocol: 'https', port: 443,
                 access_token: sAccessToken, instance: Test)
     assert_equal "Bearer #{sAccessToken}", oClient.oFaraday.headers['Authorization']
+
+    oClient = VersiononeSdk::Client.new(instance: 'Test')
+    assert_equal({'B' => 'Story', 'E' => 'Epic', 'D' => 'Defect'}, oClient.dTypePrefix)
+
+    oClient = VersiononeSdk::Client.new(instance: 'Test', type_prefixes: { 'T' => 'Test' })
+    assert_equal({ 'T' => 'Test'}, oClient.dTypePrefix)
   end
 end


### PR DESCRIPTION
This PR adds support for custom prefixes in asset types. 

I couldn't find a full list of all prefixes, so I decided that it would be best to make it configurable. 

As far as I know, there are additionally:

| Asset Type | Prefix |
| --- | --- |
| Request | R |
| Issues | I |
| RegressionTest | RT |

but I am not sure how they are enabled or disabled and if they are customizable. It appears depending on what development process you have setup, you are given different types of assets. 
